### PR TITLE
toolbox: fix data conversion

### DIFF
--- a/packages/services/src/toolbox/ToolboxServiceManager.ts
+++ b/packages/services/src/toolbox/ToolboxServiceManager.ts
@@ -1,5 +1,6 @@
 import { camelizeKeys } from 'humps';
 import { v4 as uuidv4 } from 'uuid';
+import { isString } from 'lodash-es';
 
 import { SocketReadyState } from './constants/socket';
 import { Event } from './constants/events';
@@ -95,8 +96,8 @@ class ToolboxServiceManager {
       if (message) {
         if (success) {
           message.resolve(
-            // Костыль для получения subjectKeyID в методе createTokenCertRequest
-            subjectKeyID
+            // Костыль для createTokenCertRequest, для токенов responseData присылается как строка, для остальных вариантов объект
+            isString(responseData)
               ? { value: responseData as string, subjectKeyID }
               : responseData,
           );


### PR DESCRIPTION
Делать преобразование данных по наличию  subjectKeyID - не совсем верное решение, оно SKID может не придти, но при этом для токена Data придет как строка, поэтому лучше проверять сами данные.

Проблем была обнаружение в тулбокс в приложении ЭТ
В тулбоксе скид стал необязательный в одной сборке: https://astraltrack.atlassian.net/browse/SIGN-2995